### PR TITLE
Replace polyfill for window.ga (the Google Analytics callback) with a if-exists-call

### DIFF
--- a/js/foundationExtendEBI.js
+++ b/js/foundationExtendEBI.js
@@ -11,12 +11,11 @@
 // add class verbose-analytics to your body for a readout to console on clicks, ala:
 // jQuery('body').addClass('verbose-analytics');
 // -------------
-var ga = ga || [];
 var numberOfEbiGaChecks = 0;
 var numberOfEbiGaChecksLimit = 2;
 var lastGaEventTime = Date.now(); // track the last time an event was send (don't double send)
 function ebiGaCheck() {
-  if (ga.loaded) {
+  if (ga && ga.loaded) {
     jQuery('body').addClass('google-analytics-loaded'); // Confirm GA is loaded, add a class if found
     ebiGaInit();
   } else {
@@ -56,7 +55,7 @@ function analyticsTrackInteraction(actedOnItem, parentContainer, customEventName
   // Only if more than 100ms has past since last click.
   // Due to our structure, we fire multiple events, so we only send to GA the most specific event resolution
   if ((Date.now() - lastGaEventTime) > 150) {
-    ga('send', 'event', 'UI', 'UI Element / ' + parentContainer, linkName);
+    ga && ga('send', 'event', 'UI', 'UI Element / ' + parentContainer, linkName);
     lastGaEventTime = Date.now();
 
     // conditional logging
@@ -150,7 +149,7 @@ function ebiGaInit() {
       if ( keydown !== null ) {
         var delta = new Date().getTime() - keydown;
         if ( delta > 0 && delta < 1000 ) {
-          ga('send', 'event', 'UI', 'UI Element / Keyboard', 'Browser in page search');
+          ga && ga('send', 'event', 'UI', 'UI Element / Keyboard', 'Browser in page search');
         }
         keydown = null;
       }


### PR DESCRIPTION
Expression Atlas had no analytics since its switch to foundation, this is an attempt to bring them back.


Explanation of the problem and why the solution works:


Google tells you to use analytics by including this snippet:
<script>
  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');

  ga('create','unique tracker id', 'auto');
  ga('send', 'pageview');
</script>

i[r] is window['ga'] and if it's something truthy ([] is truthy) the snippet does nothing.

At the same time foundationExtendEBI.js can not rely on window.ga being there (individual teams will have their own tracker, or not) so add an if-exists-then before each function call.