### PR TITLE
A better way to reference the global window.ga

### DIFF
--- a/js/foundationExtendEBI.js
+++ b/js/foundationExtendEBI.js
@@ -15,12 +15,10 @@ var numberOfEbiGaChecks = 0;
 var numberOfEbiGaChecksLimit = 2;
 var lastGaEventTime = Date.now(); // track the last time an event was send (don't double send)
 function ebiGaCheck() {
-  try {
-    if (ga && ga.loaded) {
-      jQuery('body').addClass('google-analytics-loaded'); // Confirm GA is loaded, add a class if found
-      ebiGaInit();
-    }
-  } catch (err) {
+  if (window.ga && window.ga.loaded) {
+    jQuery('body').addClass('google-analytics-loaded'); // Confirm GA is loaded, add a class if found
+    ebiGaInit();
+  } else {
     if (numberOfEbiGaChecks < numberOfEbiGaChecksLimit) {
       numberOfEbiGaChecks++;
       setTimeout(ebiGaCheck, 900); // give a second check if GA was slow to load
@@ -57,7 +55,7 @@ function analyticsTrackInteraction(actedOnItem, parentContainer, customEventName
   // Only if more than 100ms has past since last click.
   // Due to our structure, we fire multiple events, so we only send to GA the most specific event resolution
   if ((Date.now() - lastGaEventTime) > 150) {
-    ga && ga('send', 'event', 'UI', 'UI Element / ' + parentContainer, linkName);
+    window.ga && window.ga('send', 'event', 'UI', 'UI Element / ' + parentContainer, linkName);
     lastGaEventTime = Date.now();
 
     // conditional logging
@@ -151,7 +149,7 @@ function ebiGaInit() {
       if ( keydown !== null ) {
         var delta = new Date().getTime() - keydown;
         if ( delta > 0 && delta < 1000 ) {
-          ga && ga('send', 'event', 'UI', 'UI Element / Keyboard', 'Browser in page search');
+          window.ga && window.ga('send', 'event', 'UI', 'UI Element / Keyboard', 'Browser in page search');
         }
         keydown = null;
       }


### PR DESCRIPTION
The previous PR was my mistake and I clearly didn't test enough, sorry!

Instead of "catch when ga is undefined" reference the global object from window

You can't use an undefined global - that's the scenario for Uncaught ReferenceError - unless by seeing if it's present in window (says the Internet)

mitigates ebiwd#96

This reverts commit 3286d81