### PR TITLE
Fixes text almost touching left/right aligned images on news pages

### DIFF
--- a/css/ebi-global.css
+++ b/css/ebi-global.css
@@ -4160,7 +4160,17 @@ body .thumbnail {
 figure.image {
   display: table;
   width: 1px;
-  padding-left: .5rem; }
+  padding-left: .5rem;
+}
+
+.pane-content figure.image.float-left {
+  padding-right: 1rem;
+}
+
+.pane-content figure.image.float-right {
+  padding-left: 1rem;
+}
+
   figure.image img, figure.image figcaption {
     max-width: inherit; }
   figure.image figcaption {


### PR DESCRIPTION
I got an RT [ticket](https://helpdesk.ebi.ac.uk/SelfService/Display.html?id=494071) about image padding when its left aligned. It was closed, but this is a global fix for such issues.

Example page where I tested changes: https://www.ebi.ac.uk/about/news/feature-story/open-data-latin-america